### PR TITLE
Apply grid to the inside of the selected object - don't change it's dimensions

### DIFF
--- a/Split Into Grid.sketchplugin
+++ b/Split Into Grid.sketchplugin
@@ -33,8 +33,8 @@ var layer = selection[0];
 var frame = [layer frame];
 
 //resize it first
-[frame setWidth:[[[frame width] - [gutter*columns]] /columns]];
-[frame setHeight:[[[frame height] - [gutter*rows]] /rows]];
+[frame setWidth:[[[frame width] - [gutter*(columns-1)]] /columns]];
+[frame setHeight:[[[frame height] - [gutter*(rows-1)]] /rows]];
 
 // generate copies and position them
 for(i = 0; i < rows; i++){


### PR DESCRIPTION
## Current Behavior:

The plugin changes the object's width and height and adds a gutter to the outside
## Proposed Change:

Don't change the object's width and height, apply the grid inside the object.

Here is a Pull Request based off the comment from https://github.com/marceloeduardo/Sketch-Scripts/issues/3#issuecomment-215491211

It worked perfectly for me.

Hope that helps
